### PR TITLE
Fix docker-registry run exception: No module named wsgi

### DIFF
--- a/registry/centos6/run-registry.sh
+++ b/registry/centos6/run-registry.sh
@@ -6,5 +6,5 @@ source /etc/sysconfig/docker-registry
 export SETTINGS_FLAVOR
 
 cd /usr/lib/python2.6/site-packages/docker-registry
-exec /usr/bin/gunicorn --access-logfile - --debug --max-requests 100 --graceful-timeout 3600 -t 3600 -k gevent -b ${REGISTRY_ADDRESS}:${REGISTRY_PORT} -w $GUNICORN_WORKERS wsgi:application
+exec /usr/bin/gunicorn --access-logfile - --debug --max-requests 100 --graceful-timeout 3600 -t 3600 -k gevent -b ${REGISTRY_ADDRESS}:${REGISTRY_PORT} -w $GUNICORN_WORKERS docker_registry.wsgi:application
 


### PR DESCRIPTION
In `run-registry.sh`, used `wsgi:application`, exception trace:

```
2014-11-14 06:40:42 [23] [INFO] Worker exiting (pid: 23)
2014-11-14 06:40:42 [24] [INFO] Booting worker with pid: 24
2014-11-14 06:40:42 [24] [ERROR] Exception in worker process:
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/gunicorn/arbiter.py", line 495, in spawn_worker
    worker.init_process()
  File "/usr/lib/python2.6/site-packages/gunicorn/workers/ggevent.py", line 165, in init_process
    super(GeventWorker, self).init_process()
  File "/usr/lib/python2.6/site-packages/gunicorn/workers/base.py", line 106, in init_process
    self.wsgi = self.app.wsgi()
  File "/usr/lib/python2.6/site-packages/gunicorn/app/base.py", line 114, in wsgi
    self.callable = self.load()
  File "/usr/lib/python2.6/site-packages/gunicorn/app/wsgiapp.py", line 62, in load
    return self.load_wsgiapp()
  File "/usr/lib/python2.6/site-packages/gunicorn/app/wsgiapp.py", line 49, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/lib/python2.6/site-packages/gunicorn/util.py", line 354, in import_app
    __import__(module)
ImportError: No module named wsgi
2014-11-14 06:40:42 [25] [INFO] Worker exiting (pid: 25)
Traceback (most recent call last):
  File "/usr/bin/gunicorn", line 9, in <module>
    load_entry_point('gunicorn==18.0', 'console_scripts', 'gunicorn')()
  File "/usr/lib/python2.6/site-packages/gunicorn/app/wsgiapp.py", line 71, in run
    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
  File "/usr/lib/python2.6/site-packages/gunicorn/app/base.py", line 143, in run
    Arbiter(self).run()
  File "/usr/lib/python2.6/site-packages/gunicorn/arbiter.py", line 203, in run
    self.halt(reason=inst.reason, exit_status=inst.exit_status)
  File "/usr/lib/python2.6/site-packages/gunicorn/arbiter.py", line 298, in halt
    self.stop()
  File "/usr/lib/python2.6/site-packages/gunicorn/arbiter.py", line 341, in stop
    self.reap_workers()
  File "/usr/lib/python2.6/site-packages/gunicorn/arbiter.py", line 452, in reap_workers
    raise HaltServer(reason, self.WORKER_BOOT_ERROR)
gunicorn.errors.HaltServer: <HaltServer 'Worker failed to boot.' 3>
```
