### PR TITLE
Update deprecated '-rm'.  Replace '-t' with '--tag' to make it more clear.

### DIFF
--- a/nginx/centos7/README.md
+++ b/nginx/centos7/README.md
@@ -7,7 +7,7 @@ To build:
 
 Copy the sources down -
 
-    # docker build -rm -t <username>/nginx:centos7 .
+    # docker build --rm --tag <username>/nginx:centos7 .
 
 To run:
 


### PR DESCRIPTION
'-rm' is deprecated.