### PR TITLE
Remove space in run-httpd.sh

### DIFF
--- a/httpd/centos7/run-httpd.sh
+++ b/httpd/centos7/run-httpd.sh
@@ -5,4 +5,4 @@
 # if it thinks it is already running.
 rm -rf /run/httpd/* /tmp/httpd*
 
-exec /usr/sbin/apachectl -D FOREGROUND
+exec /usr/sbin/apachectl -DFOREGROUND


### PR DESCRIPTION
apachectl complains "Passing arguments to httpd using apachectl is no longer supported." when passing -D FOREGROUND as arguments.
Running apachectl with -DFOREGROUND keeps the script from complaining about extra arguments.