### PR TITLE
Use env vars, used in official image, in CentOS 7 postges image.

### DIFF
--- a/postgres/centos7/start_postgres.sh
+++ b/postgres/centos7/start_postgres.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-DB_NAME=${DB_NAME:-}
-DB_USER=${DB_USER:-}
-DB_PASS=${DB_PASS:-}
+DB_NAME=${POSTGRES_DB:-}
+DB_USER=${POSTGRES_USER:-}
+DB_PASS=${POSTGRES_PASSWORD:-}
 PG_CONFDIR="/var/lib/pgsql/data"
 
 __create_user() {


### PR DESCRIPTION
Use same env variable names in centos 7 postgresql image
similar to official postgres image.