### PR TITLE
redis: specify an entrypoint and a cmd

### DIFF
--- a/redis/centos7/Dockerfile
+++ b/redis/centos7/Dockerfile
@@ -22,4 +22,5 @@ RUN ./fix-permissions.sh /var/log/redis/ && \
 # everywhere else
 USER 997
 	
-ENTRYPOINT ["redis-server", "/etc/redis.conf", "--bind", "0.0.0.0"]
+ENTRYPOINT ["redis-server"]
+CMD ["/etc/redis.conf", "--bind", "0.0.0.0"]


### PR DESCRIPTION
This makes it easier to override the default arguments on the docker
command line.