### PR TITLE
Add Docker Registry v2 (aka Distribution)

### DIFF
--- a/registry-v2/centos7/Dockerfile
+++ b/registry-v2/centos7/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos:7
+MAINTAINER The CentOS Project <cloud-ops@centos.org>
+
+RUN yum -y install docker-distribution; yum clean all
+
+EXPOSE 5000
+
+USER 42
+
+ENTRYPOINT ["/usr/bin/registry"]
+CMD ["/etc/docker-distribution/registry/config.yml"]

--- a/registry-v2/centos7/README.md
+++ b/registry-v2/centos7/README.md
@@ -1,0 +1,19 @@
+Docker Registry v2 (aka Distribution)
+========================
+
+CentOS7 Dockerfile for Docker Registry v2
+
+To build:
+```bash
+docker build -t <yourname>/registry .
+```
+
+To run:
+```bash
+docker run -d -p 5000:5000 <yourname>/registry
+```
+
+To use a persistent storage run it as:
+```bash
+docker run -d -p 5000:5000 -v /var/lib/registry:/var/lib/registry:Z <yourname>/registry
+```


### PR DESCRIPTION
This is the new Docker Registry v2 (aka Distribution). The old one 0.x (which is currently in the repository) is deprecated for quite some time.

Please set up an automated build on Docker Hub and publish this probably as "centos/registry:2".

Thanks.