### PR TITLE
Make registry-v2 command use "serve"

### DIFF
--- a/registry-v2/centos7/Dockerfile
+++ b/registry-v2/centos7/Dockerfile
@@ -8,4 +8,4 @@ EXPOSE 5000
 USER 42
 
 ENTRYPOINT ["/usr/bin/registry"]
-CMD ["/etc/docker-distribution/registry/config.yml"]
+CMD ["serve", "/etc/docker-distribution/registry/config.yml"]


### PR DESCRIPTION
The CMD in the registry-v2 Dockerfile needs to specify "serve" before the configuration.