### PR TITLE
typo: postgres - centos7 environment variable

### DIFF
--- a/postgres/centos7/README.md
+++ b/postgres/centos7/README.md
@@ -32,9 +32,9 @@ You can create a postgresql superuser at launch by specifying `DB_USER` and
 `DB_PASS` variables. You may also create a database by using `DB_NAME`. 
 
     docker run --name postgresql -d \
-    -e 'DB_USER=username' \
-    -e 'DB_PASS=ridiculously-complex_password1' \
-    -e 'DB_NAME=my_database' \
+    -e 'POSTGRES_USER=username' \
+    -e 'POSTGRES_PASSWORD=ridiculously-complex_password1' \
+    -e 'POSTGRES_DB=my_database' \
     <yourname>/postgresql
 
 To connect to your database with your newly created user:

--- a/postgres/centos7/README.md
+++ b/postgres/centos7/README.md
@@ -8,7 +8,7 @@ Setup
 
 To build the image
 
-    # docker build --rm -t <yourname/postgresql .
+    # docker build --rm -t <yourname>/postgresql .
 
 
 Launching PostgreSQL
@@ -21,7 +21,7 @@ Launching PostgreSQL
 
 To connect to the container as the administrative `postgres` user:
 
-    docker run -it --rm --volumes-from=postgresql <yourname>/postgres sudo -u
+    docker run -it --rm --volumes-from=postgresql <yourname>/postgresql sudo -u
     postgres -H psql
 
 


### PR DESCRIPTION
README.md is not updated with 133418fdcc957feba287b6f875ac61852a1827d2 change.
