### PR TITLE
install pwgen used in start_postgres.sh

### DIFF
--- a/postgres/centos7/Dockerfile
+++ b/postgres/centos7/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER The CentOS Project <cloud-ops@centos.org>
 
 RUN yum -y update; yum clean all
 RUN yum -y install sudo epel-release; yum clean all
-RUN yum -y install postgresql-server postgresql postgresql-contrib supervisor; yum clean all
+RUN yum -y install postgresql-server postgresql postgresql-contrib supervisor pwgen; yum clean all
 
 ADD ./postgresql-setup /usr/bin/postgresql-setup
 ADD ./supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
Command `pwgen` is not installed although [used in `start_postgres.sh`](https://github.com/CentOS/CentOS-Dockerfiles/blob/133418fdcc957feba287b6f875ac61852a1827d2/postgres/centos7/start_postgres.sh#L19).