### PR TITLE
Added cccp.yml to postgres to build it through container pipeline

### DIFF
--- a/postgres/centos7/cccp.yml
+++ b/postgres/centos7/cccp.yml
@@ -1,0 +1,5 @@
+# This is for the purpose of building the container through the CentOS Communnity 
+# Container Pipeline. https://github.com/CentOS/container-index 
+
+job-id: postgres
+test-skip: true


### PR DESCRIPTION
* for getting centos postgres built through centos community container pipeline, we need the cccp.yml file to be present in the same dir as Dockerfile.
