### PR TITLE
Revert "tiny updates and closing #79"

### DIFF
--- a/httpd/centos7/Dockerfile
+++ b/httpd/centos7/Dockerfile
@@ -1,23 +1,16 @@
-FROM centos:centos7
+FROM centos:latest
+MAINTAINER http://www.centos.org
+LABEL Vendor="CentOS"
+LABEL License=GPLv2
+LABEL Version=2.4.6-31
 
-MAINTAINER The CentOS Project <cloud-ops@centos.org>
+RUN yum -y update && yum clean all
+RUN yum -y install httpd && yum clean all
 
-LABEL Vendor="CentOS" \
-      License=GPLv2 \
-      Version=2.4.6-40
+EXPOSE 80
 
-RUN yum -y --setopt=tsflags=nodocs update && \
-    yum -y --setopt=tsflags=nodocs install httpd && \
-    yum clean all
+# Simple startup script to avoid some issues observed with container restart 
+ADD run-httpd.sh /run-httpd.sh
+RUN chmod -v +x /run-httpd.sh
 
-EXPOSE 8080
-
-# need to change some permissions to allow non-root user to start things
-# had to do these steps to give the httpd deamon the ability to.
-# This actually appears due to a bug with Windows and Mac. It looks like
-# we could have just "ls" on the directory to get the chmod to stick
-RUN rm -rf /run/httpd && mkdir /run/httpd && chmod -R a+rwx /run/httpd
-
-USER 1001
-
-CMD [ "/usr/sbin/apachectl" "-DFOREGROUND" ]
+CMD ["/run-httpd.sh"]

--- a/httpd/centos7/README.md
+++ b/httpd/centos7/README.md
@@ -1,28 +1,32 @@
-# dockerfiles-centos-httpd
+dockerfiles-centos-httpd
+========================
 
-CentOS Dockerfile for Apache httpd
+CentOS  dockerfile for httpd
 
+Get Docker version
 
-## Build
+```
+# docker version
+```
 
-Copy the sources down and do the build
+To build:
+
+Copy the sources down and do the build-
 
 ```
 # docker build --rm -t <username>/httpd .
 ```
 
-## Usage
-
-To run (if port 8080 is available and open on your host):
+To run (if port 80 is open on your host):
 
 ```
-# docker run -d -p 8080:8080 <username>/httpd
+# docker run -d -p 80:80 <username>/httpd
 ```
 
 or to assign a random port that maps to port 80 on the container:
 
 ```
-# docker run -d -p 8080 <username>/httpd
+# docker run -d -p 80 <username>/httpd
 ```
 
 To the port that the container is listening on:
@@ -31,8 +35,8 @@ To the port that the container is listening on:
 # docker ps
 ```
 
-## Test
+To test:
 
 ```
-# curl http://localhost:8080
+# curl http://localhost
 ```

--- a/httpd/centos7/run-httpd.sh
+++ b/httpd/centos7/run-httpd.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Make sure we're not confused by old, incompletely-shutdown httpd
+# context after restarting the container.  httpd won't start correctly
+# if it thinks it is already running.
+rm -rf /run/httpd/* /tmp/httpd*
+
+exec /usr/sbin/apachectl -DFOREGROUND


### PR DESCRIPTION
This reverts commit 9effa48b68857a0511f6878162f46f2000ee3d29.

ಠ_ಠ  That "tiny update" broke everything:

- The exposed port changed from 80 to 8080, but the `Listen` directive in `/etc/httpd/conf/httpd.conf` was not updated accordingly
- User 1001 (whoever that is) has no permissions to `/etc/httpd` and probably other necessary directories
- I don't even think user 1001 exists. I could be wrong about that.

I am shocked and amazed at how this ever got merged.

For those affected by this in need of a quick workaround, a working version of the image is up on https://hub.docker.com/r/larsbutler/httpd/. Use `FROM larsbutler/httpd` instead of `centos/httpd`.