### PR TITLE
Added functional elastic search container with v2.4 on openshift.

### DIFF
--- a/elasticsearch/centos7/Dockerfile.24
+++ b/elasticsearch/centos7/Dockerfile.24
@@ -1,0 +1,18 @@
+FROM registry.centos.org/centos/centos:7
+
+MAINTAINER Mohammed Zeeshan Ahmed<moahmed@redhat.com>
+
+# RUN yum -y update && yum clean all
+
+ENV ELASTIC_MAJOR_VERSION="2.4.0"
+
+ADD fix-permissions.sh install_older_versions.sh run.sh passwd.template /opt/scripts/
+
+RUN . /opt/scripts/install_older_versions.sh
+
+USER elasticsearch
+
+EXPOSE 9200 9300
+
+ENTRYPOINT ["/opt/scripts/run.sh"]
+CMD ["elastic"]

--- a/elasticsearch/centos7/Dockerfile.53
+++ b/elasticsearch/centos7/Dockerfile.53
@@ -1,0 +1,16 @@
+FROM registry.centos.org/centos/centos:7
+
+MAINTAINER Mohammed Zeeshan Ahmed<moahmed@redhat.com>
+
+# RUN yum -y update && yum clean all
+
+ADD fix-permissions.sh install.sh run.sh passwd.template /opt/scripts/
+
+RUN . /opt/scripts/install.sh
+
+USER 1001
+
+EXPOSE 9200 9300
+
+ENTRYPOINT ["/opt/scripts/run.sh"]
+CMD ["elastic"]

--- a/elasticsearch/centos7/fix-permissions.sh
+++ b/elasticsearch/centos7/fix-permissions.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Fix permissions on the given directory to allow group read/write of
+# regular files and execute of directories.
+set -eux
+find "$1" -exec chown ${2} {} \;
+find "$1" -exec chgrp 0 {} \;
+find "$1" -exec chmod g+rw {} \;
+find "$1" -type d -exec chmod g+x {} +

--- a/elasticsearch/centos7/install.sh
+++ b/elasticsearch/centos7/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -eux;
+
+# Initialize Variables
+
+ELASTIC_SEARCH_GPG_KEY="https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+ELASTIC_REPO_FILE_LOCATION="/etc/yum.repos.d/elastic.repo"
+ELASTIC_CONFIG="/etc/elasticsearch/elasticsearch.yml"
+ELASTIC_CONFIG_BAK="/etc/elasticsearch/elasticsearch.yml.bak"
+ELASTIC_MAJOR_VERSION=${ELASTIC_MAJOR_VERSION:-"5.x"}
+BASIC_PACKAGES="java-1.8.0-openjdk nss_wrapper gettext"
+SYSCTL_CONF="/etc/sysctl.conf"
+
+# Install Begins
+
+# Install epel
+yum -y install epel-release;
+
+# Configure Elastic Repo
+cat >${ELASTIC_REPO_FILE_LOCATION} <<EOF
+[ElasticSearch]
+name=Elasticsearch repository for ${ELASTIC_MAJOR_VERSION} packages
+baseurl=https://artifacts.elastic.co/packages/${ELASTIC_MAJOR_VERSION}/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
+EOF
+
+# Create elasticsearch user
+useradd -u 1001 -g 0 elasticsearch
+
+# Install basic packages
+yum -y install ${BASIC_PACKAGES};
+
+# Install elastic search
+yum -y install elasticsearch;
+ln -s /etc/elasticsearch/ /usr/share/elasticsearch/config
+cp ${ELASTIC_CONFIG} ${ELASTIC_CONFIG_BAK}
+
+for item in "/usr/share/elasticsearch" "/etc/elasticsearch" "/var/lib/elasticsearch" "/etc/sysconfig/elasticsearch"; do
+    . /opt/scripts/fix-permissions.sh ${item} elasticsearch
+done
+
+# Cleanup
+yum clean all

--- a/elasticsearch/centos7/install_older_versions.sh
+++ b/elasticsearch/centos7/install_older_versions.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eux;
+
+# Initialize Variables
+
+ELASTIC_CONFIG="/etc/elasticsearch/elasticsearch.yml"
+ELASTIC_CONFIG_BAK="/etc/elasticsearch/elasticsearch.yml.bak"
+ELASTIC_MAJOR_VERSION=${ELASTIC_MAJOR_VERSION:-"5.x"}
+BASIC_PACKAGES="java-1.8.0-openjdk nss_wrapper gettext"
+SYSCTL_CONF="/etc/sysctl.conf"
+
+# Install Begins
+
+# Install epel
+yum -y install epel-release;
+
+# Configure Elastic Repo
+yum -y install https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/${ELASTIC_MAJOR_VERSION}/elasticsearch-${ELASTIC_MAJOR_VERSION}.rpm
+
+# Install basic packages
+yum -y install ${BASIC_PACKAGES};
+
+# Install elastic search
+yum -y install elasticsearch;
+ln -s /etc/elasticsearch/ /usr/share/elasticsearch/config
+cp ${ELASTIC_CONFIG} ${ELASTIC_CONFIG_BAK}
+
+# Modify elasticsearch user
+usermod -g 0 elasticsearch
+
+for item in "/usr/share/elasticsearch" "/etc/elasticsearch" "/var/lib/elasticsearch" "/etc/sysconfig/elasticsearch"; do
+    . /opt/scripts/fix-permissions.sh ${item} elasticsearch
+done
+
+# Cleanup
+yum clean all

--- a/elasticsearch/centos7/passwd.template
+++ b/elasticsearch/centos7/passwd.template
@@ -1,0 +1,14 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+elasticsearch:x:${USER_ID}:${GROUP_ID}:Apache User:${HOME}:/bin/bash

--- a/elasticsearch/centos7/run.sh
+++ b/elasticsearch/centos7/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Permissions
+export USER_ID=$(id -u);
+export GROUP_ID=$(id -g);
+envsubst < /opt/scripts/passwd.template > /tmp/passwd;
+export LD_PRELOAD=libnss_wrapper.so;
+export NSS_WRAPPER_PASSWD=/tmp/passwd;
+export NSS_WRAPPER_GROUP=/etc/group;
+ELASTIC_CONFIG="/etc/elasticsearch/elasticsearch.yml";
+ELASTIC_CONFIG_BAK="/etc/elasticsearch/elasticsearch.yml.bak";
+
+rm -rf ${ELASTIC_CONFIG};
+cp ${ELASTIC_CONFIG_BAK} ${ELASTIC_CONFIG};
+
+cat >>${ELASTIC_CONFIG} <<EOF
+network.host: 0.0.0.0
+discovery.zen.minimum_master_nodes: 1
+http.cors.enabled: true
+http.cors.allow-origin: /http://localhost(:[0-9]+)?/
+EOF
+
+# Main Begins
+if [ $1 == "elastic" ]; then
+
+    exec /usr/share/elasticsearch/bin/elasticsearch;
+else
+    exec $@
+fi


### PR DESCRIPTION
Currently only 2.4 is functional on openshift due to issues with
sysctl. I have created the 5.x container as well but its not
currently operational on openshift, but it works if sysctl is
configured with vm.max_map_count=262144. So more work will need
to be done once kubernetes fixes sysctl issue.

https://github.com/CentOS/CentOS-Dockerfiles/issues/131