### PR TITLE
Make it possible to specify charset and collation for MariaDB

### DIFF
--- a/mariadb/centos7/README.md
+++ b/mariadb/centos7/README.md
@@ -43,6 +43,7 @@ And now create the daemonized mariadb container:
     # docker run --name=mariadb -d -p 3306:3306 --volumes-from=mariadb-data -e MYSQL_ROOT_PASSWORD=<password> <yourname>/mariadb55
 
 You could also create an additional database by passing MYSQL_DATABASE and/or create an additional user passing MYSQL_USER to the container.
+You can specify database character set and/or collation by specifying MYSQL_CHARSET and/or MYSQL_COLLATION!
 
 Using your MariaDB container
 ----------------------------

--- a/mariadb/centos7/docker-entrypoint.sh
+++ b/mariadb/centos7/docker-entrypoint.sh
@@ -33,6 +33,13 @@ if [ "$1" = 'mysqld_safe' ]; then
 		
 		if [ "$MYSQL_DATABASE" ]; then
 			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
+			if [ "$MYSQL_CHARSET" ]; then
+				echo "ALTER DATABASE \`$MYSQL_DATABASE\` CHARACTER SET \`$MYSQL_CHARSET\` ;" >> "$tempSqlFile"
+			fi
+			
+			if [ "$MYSQL_COLLATION" ]; then
+				echo "ALTER DATABASE \`$MYSQL_DATABASE\` COLLATE \`$MYSQL_COLLATION\` ;" >> "$tempSqlFile"
+			fi
 		fi
 		
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then


### PR DESCRIPTION
For my database I use `CHARACTER SET utf8 COLLATE utf8_unicode_ci` and this PR makes it possible to configure these. 

I'm not sure what to do about versioning. Is the image on Docker Hub going to be rebuilt after this PR has been merged ?