### PR TITLE
Install sudo

### DIFF
--- a/postgres/centos7/Dockerfile
+++ b/postgres/centos7/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER The CentOS Project <cloud-ops@centos.org>
 
 RUN yum -y update; yum clean all
 RUN yum -y install sudo epel-release; yum clean all
-RUN yum -y install postgresql-server postgresql postgresql-contrib supervisor pwgen; yum clean all
+RUN yum -y install postgresql-server postgresql postgresql-contrib supervisor pwgen sudo; yum clean all
 
 ADD ./postgresql-setup /usr/bin/postgresql-setup
 ADD ./supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
Docker file fails to build when attempting step `RUN sed -i 's/.*requiretty$/#Defaults requiretty/' /etc/sudoers` since `sudo` does not exist