### PR TITLE
Adds $GOPATH/bin to PATH and reduces an extra layer from image

### DIFF
--- a/golang/centos7/Dockerfile
+++ b/golang/centos7/Dockerfile
@@ -1,10 +1,11 @@
 FROM centos:7
 
-RUN yum -y update && yum clean all
-
-RUN mkdir -p /go && chmod -R 777 /go && \
-    yum -y install git golang && yum clean all
-
 ENV GOPATH /go
 
-WORKDIR /go
+RUN yum -y update && \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" && \
+    yum -y install git golang && yum clean all
+
+ENV PATH $PATH:$GOPATH/bin
+
+WORKDIR $GOPATH


### PR DESCRIPTION
  Merges `yum -y update` layer with `yum install golang` layer.
  Creates $GOPATH/src and $GOPATH/bin directories.
  Appends $GOPATH/bin to $PATH env variable.
  Uses $GOPATH as workdir instead of hard cording `/go`.