### PR TITLE
Updating url for caddy server upload plugin.

### DIFF
--- a/caddy_server/centos7/README.md
+++ b/caddy_server/centos7/README.md
@@ -8,7 +8,32 @@ By default, content present inside `/var/www/html` will be served over web on th
 
 ### Caddy server plugins installed by default:
 
-List of installed plugins is available in 'plugin_list' file in same directory.
+List of installed plugins is available in 'plugin_list' file in same directory. For reference : 
+
+#### http.login
+github.com/casbin/caddy-authz
+#### http.cgi
+github.com/jung-kurt/caddy-cgi
+#### http.cors
+github.com/captncraig/cors
+#### http.git
+github.com/abiosoft/caddy-git
+#### http.datadog
+github.com/payintech/caddy-datadog
+#### http.cache
+github.com/nicolasazrak/caddy-cache
+#### http.locale
+github.com/simia-tech/caddy-locale
+#### http.filter
+github.com/echocat/caddy-filter
+#### http.ratelimit
+github.com/xuqingfeng/caddy-rate-limit
+#### http.upload
+blitznote.com/src/caddy.upload
+#### http.awses
+github.com/miquella/caddy-awses
+#### http.prometheus
+github.com/miekg/caddy-prometheus
 
 ### Caddy Server Configuration
 

--- a/caddy_server/centos7/plugin_list
+++ b/caddy_server/centos7/plugin_list
@@ -17,7 +17,7 @@ github.com/echocat/caddy-filter
 # http.ratelimit
 github.com/xuqingfeng/caddy-rate-limit
 # http.upload
-github.com/wmark/caddy.upload
+blitznote.com/src/caddy.upload
 # http.awses
 github.com/miquella/caddy-awses
 # http.prometheus


### PR DESCRIPTION
The expected url for for upload plugin appears to be different from github.com. Updating the same.
Build succeeds with this.