### PR TITLE
Fix dockerfile user from 997 to nginx

### DIFF
--- a/nginx/centos7/Dockerfile
+++ b/nginx/centos7/Dockerfile
@@ -47,7 +47,7 @@ RUN echo "nginx on CentOS7" > /usr/share/nginx/html/index.html
 
 EXPOSE 80
 
-USER 997
+USER nginx
 
 ENTRYPOINT ["container-entrypoint"]
 CMD [ "nginx18" ]


### PR DESCRIPTION
This PR fixes the UID mismatch inside of the Dockerfile.

The UID 997 did not match the real nginx user
inside of the container. The nginx UID is 999.

Fixed by switching from UID to username.

Signed-off-by: Petr Kotas <petr.kotas@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/centos/centos-dockerfiles/178)
<!-- Reviewable:end -->
