### PR TITLE
Install golang binary using the go-toolset

### DIFF
--- a/golang/centos7/Dockerfile
+++ b/golang/centos7/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir -p /go && chmod -R 777 /go && \
     yum -y install git go-toolset-7-golang && yum clean all
 
 ENV GOPATH=/go \
-    PATH=/opt/rh/go-toolset-7/root/usr/bin:/opt/rh/go-toolset-7/root/usr/sbin:$PATH
+    BASH_ENV=/opt/rh/go-toolset-7/enable \
+    ENV=/opt/rh/go-toolset-7/enable \
+    PROMPT_COMMAND=". /opt/rh/go-toolset-7/enable"
 
 WORKDIR /go

--- a/golang/centos7/Dockerfile
+++ b/golang/centos7/Dockerfile
@@ -3,8 +3,10 @@ FROM centos:7
 RUN yum -y update && yum clean all
 
 RUN mkdir -p /go && chmod -R 777 /go && \
-    yum -y install git golang && yum clean all
+    yum install -y centos-release-scl && \
+    yum -y install git go-toolset-7-golang && yum clean all
 
-ENV GOPATH /go
+ENV GOPATH=/go \
+    PATH=/opt/rh/go-toolset-7/root/usr/bin:/opt/rh/go-toolset-7/root/usr/sbin:$PATH
 
 WORKDIR /go


### PR DESCRIPTION
`golang` is no longer a part of the distribution and `go-toolset` is the way to install Go in CentOS. 