### PR TITLE
The MAINTAINER instruction has been deprecated.

### DIFF
--- a/systemd/centos7/Dockerfile
+++ b/systemd/centos7/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 ENV container docker
-MAINTAINER The CentOS Project <cloud-ops@centos.org>
+LABEL maintainer="The CentOS Project <cloud-ops@centos.org>"
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*;\


### PR DESCRIPTION
Refer to https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
The MAINTAINER instruction has been deprecated, use The LABEL instruction instead.