### PR TITLE
The MAINTAINER instruction has been deprecated.

### DIFF
--- a/systemd/centos7/README.md
+++ b/systemd/centos7/README.md
@@ -11,7 +11,7 @@ First create a Dockerfile and setup the required service or services. Systemd ca
 ```
 FROM centos/systemd
 
-MAINTAINER "Your Name" <you@example.com>
+LABEL maintainer="Your Name <you@example.com>"
 
 RUN yum -y install httpd; yum clean all; systemctl enable httpd.service
 


### PR DESCRIPTION
Refer to https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
The MAINTAINER instruction has been deprecated, use The LABEL instruction instead.